### PR TITLE
Start the animation after window load

### DIFF
--- a/3d-plan.html
+++ b/3d-plan.html
@@ -21,21 +21,23 @@
 	background: url(images/loader-64x/6.gif) center no-repeat #fff;
 }
 		</style>
-	
+
 		<link rel="stylesheet" type="text/css" href="css/demo.css" />
 		<link rel="stylesheet" type="text/css" href="css/style2.css" />
 		<link rel="stylesheet" type="text/css" href="css/normalize.css" />
 		<link rel="stylesheet" type="text/css" href="css/style.css" />
 		<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
-		
+
 		<script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.js"></script>
 
 		<script>
 		$(window).load(function() {
-		// Animate loader off screen
-		$(".se-pre-con").fadeOut("slow");;
+      // Animate loader off screen
+      $(".se-pre-con").fadeOut("slow", function() {
+        $(".container-splash").addClass("loaded");
+      });
 		});
-	
+
 			function logoError(image) {
 					image.onerror = "";
 					image.src = "logo-placeholder.png";
@@ -54,7 +56,7 @@
 
 
 		<script src="js/modernizr-custom.js"></script>
-		
+
 	</head>
 	<body>
 	<div class="se-pre-con"></div>
@@ -123,7 +125,7 @@
 						<img class="surroundings__map" src="img/surroundings.svg" alt="Surroundings"/>
 					</div>
 					<!-- enterance pic -->
-			
+
 					<div class="content__profile-photo enterance_photo">
 						<img onerror="profileError(this);" src="enterance.jpg" width="100%" alt="Profile Picture" />
 					</div>

--- a/css/style2.css
+++ b/css/style2.css
@@ -5,7 +5,7 @@ h1.main,p.demos {
 	-ms-animation-delay: 18s;
 	animation-delay: 18s;
 }
-.sp-container {
+.loaded .sp-container {
 	font-family: 'BebasNeueRegular';
 	position: fixed;
 	top: 0px;
@@ -20,7 +20,7 @@ h1.main,p.demos {
 }
 .sp-content {
  background: url(../images/red_texture3.jpg);
- height: 100%; 
+ height: 100%;
 
  /* Center and scale the image nicely */
  background-position: center;
@@ -32,13 +32,13 @@ h1.main,p.demos {
 	top: 0px;
 	z-index: 1000;
 }
-@media (max-width:480px)  { 
-	/* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones (Android) */ 
+@media (max-width:480px)  {
+	/* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones (Android) */
 	.sp-content {
 		background: url(../images/greycompressed.jpg);
 	}
 }
-.sp-container h2 {
+.loaded .sp-container h2 {
 	position: absolute;
 	top: 50%;
 	line-height: 100px;
@@ -53,32 +53,32 @@ h1.main,p.demos {
 	-ms-animation: blurFadeInOut 3s ease-in backwards;
 	animation: blurFadeInOut 3s ease-in backwards;
 }
-.sp-container h2.frame-1 {
+.loaded .sp-container h2.frame-1 {
 	-webkit-animation-delay: 0s;
 	-moz-animation-delay: 0s;
 	-ms-animation-delay: 0s;
 	animation-delay: 0s;
 }
-.sp-container h2.frame-2 {
+.loaded .sp-container h2.frame-2 {
 	-webkit-animation-delay: 3s;
 	-moz-animation-delay: 3s;
 	-ms-animation-delay: 3s;
 	animation-delay: 3s;
 }
-.sp-container h2.frame-3 {
+.loaded .sp-container h2.frame-3 {
 	-webkit-animation-delay: 6s;
 	-moz-animation-delay: 6s;
 	-ms-animation-delay: 6s;
 	animation-delay: 6s;
 }
-.sp-container h2.frame-4 {
+.loaded .sp-container h2.frame-4 {
 	font-size: 200px;
 	-webkit-animation-delay: 9s;
 	-moz-animation-delay: 9s;
 	-ms-animation-delay: 9s;
 	animation-delay: 9s;
 }
-.sp-container h2.frame-5 {
+.loaded .sp-container h2.frame-5 {
 	-webkit-animation: none;
 	-moz-animation: none;
 	-ms-animation: none;
@@ -86,7 +86,7 @@ h1.main,p.demos {
 	color: transparent;
 	text-shadow: 0px 0px 1px #fff;
 }
-.sp-container h2.frame-5 span {
+.loaded .sp-container h2.frame-5 span {
 	-webkit-animation: blurFadeIn 3s ease-in 12s backwards;
 	-moz-animation: blurFadeIn 1s ease-in 12s backwards;
 	-ms-animation: blurFadeIn 3s ease-in 12s backwards;
@@ -94,13 +94,13 @@ h1.main,p.demos {
 	color: transparent;
 	text-shadow: 0px 0px 1px #fff;
 }
-.sp-container h2.frame-5 span:nth-child(2) {
+.loaded .sp-container h2.frame-5 span:nth-child(2) {
 	-webkit-animation-delay: 13s;
 	-moz-animation-delay: 13s;
 	-ms-animation-delay: 13s;
 	animation-delay: 13s;
 }
-.sp-container h2.frame-5 span:nth-child(3) {
+.loaded .sp-container h2.frame-5 span:nth-child(3) {
 	-webkit-animation-delay: 14s;
 	-moz-animation-delay: 14s;
 	-ms-animation-delay: 14s;
@@ -127,7 +127,7 @@ h1.main,p.demos {
 	-ms-transform: scale(5);
 	transform: scale(5);
 }
-.sp-circle-link {
+.loaded .sp-circle-link {
 	position: absolute;
 	left: 50%;
 	bottom: 100px;


### PR DESCRIPTION
The animation is starting once the element are in the DOM, which is sooner than the window finished to load so the starts even the loader still there.

The logic should be to wait until `window.load` so my suggestion is to add a `class` to the parent element and define the animation only when the parent has the loaded class.

There is still some freeze at the beginning of the first title's animation in slow networks, I'm not sure but this PR is a start